### PR TITLE
use openapi-spec-validator instead of swagger-validator

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -9,7 +9,6 @@ egg-info:
 	cd .. && python setup.py egg_info
 
 pull-images:
-	docker pull swaggerapi/swagger-validator
 	docker pull wazopbx/wait
 	docker pull wazopbx/wazo-auth-mock
 	docker pull wazopbx/wazo-confd-mock

--- a/integration_tests/assets/docker-compose.documentation.override.yml
+++ b/integration_tests/assets/docker-compose.documentation.override.yml
@@ -2,12 +2,6 @@ version: '3.7'
 services:
   sync:
     depends_on:
-      - swagger-validator
       - setupd
     environment:
-      TARGETS: setupd:9302 swagger-validator:8080
-
-  swagger-validator:
-    image: swaggerapi/swagger-validator
-    ports:
-      - '8080'
+      TARGETS: setupd:9302

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,13 +1,18 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
 import requests
-import pprint
+import yaml
 
-from hamcrest import assert_that, empty
+from openapi_spec_validator import validate_v2_spec
 
 from .helpers.base import BaseIntegrationTest
 from .helpers.wait_strategy import NoWaitStrategy
+
+
+logger = logging.getLogger('openapi_spec_validator')
+logger.setLevel(logging.INFO)
 
 
 class TestDocumentation(BaseIntegrationTest):
@@ -16,11 +21,7 @@ class TestDocumentation(BaseIntegrationTest):
     wait_strategy = NoWaitStrategy()
 
     def test_documentation_errors(self):
-        api_url = 'https://setupd:9302/1.0/api/api.yml'
-        self.validate_api(api_url)
-
-    def validate_api(self, url):
-        validator_port = self.service_port(8080, 'swagger-validator')
-        validator_url = 'http://localhost:{port}/debug'.format(port=validator_port)
-        response = requests.get(validator_url, params={'url': url})
-        assert_that(response.json(), empty(), pprint.pformat(response.json()))
+        port = self.service_port(9302, 'setupd')
+        api_url = 'https://localhost:{port}/1.0/api/api.yml'.format(port=port)
+        api = requests.get(api_url, verify=False)
+        validate_v2_spec(yaml.safe_load(api.text))

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,5 +1,6 @@
 docker-compose
 kombu
+openapi-spec-validator
 pyhamcrest
 pytest
 requests


### PR DESCRIPTION
reason: openapi-spec-validator catches more errors